### PR TITLE
json apis

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -4,6 +4,13 @@ import * as fs from 'fs';
 
 let sampleFilePath: string = path.join(__dirname, 'testoutput.txt');
 
+interface HttpBinData {
+    url: string;
+    data: any;
+    json: any;
+    args?: any
+}
+
 describe('basics', () => {
     let _http: httpm.HttpClient;
 
@@ -191,5 +198,45 @@ describe('basics', () => {
         expect(res.message.statusCode).toBe(404);
         let body: string = await res.readBody();
         done();
+    });
+    
+    it('gets a json object', async() => {
+        let jsonObj: httpm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/get');
+        expect(jsonObj.statusCode).toBe(200);
+        expect(jsonObj.result).toBeDefined();
+        expect(jsonObj.result.url).toBe('https://httpbin.org/get');
+    });
+    
+    it('getting a non existent json object returns null', async() => {
+        let jsonObj: httpm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/status/404');
+        expect(jsonObj.statusCode).toBe(404);
+        expect(jsonObj.result).toBeNull();
+    });
+
+    it('posts a json object', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.postJson<HttpBinData>('https://httpbin.org/post', res);
+        expect(restRes.statusCode).toBe(200);
+        expect(restRes.result).toBeDefined(); 
+        expect(restRes.result.url).toBe('https://httpbin.org/post');
+        expect(restRes.result.json.name).toBe('foo');
+    });
+
+    it('puts a json object', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.putJson<HttpBinData>('https://httpbin.org/put', res);
+        expect(restRes.statusCode).toBe(200);
+        expect(restRes.result).toBeDefined(); 
+        expect(restRes.result.url).toBe('https://httpbin.org/put');
+        expect(restRes.result.json.name).toBe('foo');
+    });
+    
+    it('patch a json object', async() => {
+        let res: any = { name: 'foo' };
+        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.patchJson<HttpBinData>('https://httpbin.org/patch', res);
+        expect(restRes.statusCode).toBe(200);
+        expect(restRes.result).toBeDefined(); 
+        expect(restRes.result.url).toBe('https://httpbin.org/patch');
+        expect(restRes.result.json.name).toBe('foo');
     });    
 })

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -42,6 +42,7 @@ export interface IRequestOptions {
     maxRedirects?: number;
     maxSockets?: number;
     keepAlive?: boolean;
+    deserializeDates?: boolean;
     // Allows retries only on Read operations (since writes may not be idempotent)
     allowRetries?: boolean;
     maxRetries?: number;


### PR DESCRIPTION
create, post, put and patch a json object.
These are convenience wrappers.
Not they do not imply REST (and the rest goals) although they can be used to access rest apis of a service (that work with json). 