### PR TITLE
Move interface to Interfaces. Allow any for post/put/patchJson bodies

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -1,4 +1,5 @@
 import * as httpm from '../_out';
+import * as ifm from '../_out/interfaces'
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -201,21 +202,21 @@ describe('basics', () => {
     });
     
     it('gets a json object', async() => {
-        let jsonObj: httpm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/get');
+        let jsonObj: ifm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/get');
         expect(jsonObj.statusCode).toBe(200);
         expect(jsonObj.result).toBeDefined();
         expect(jsonObj.result.url).toBe('https://httpbin.org/get');
     });
     
     it('getting a non existent json object returns null', async() => {
-        let jsonObj: httpm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/status/404');
+        let jsonObj: ifm.ITypedResponse<HttpBinData> = await _http.getJson<HttpBinData>('https://httpbin.org/status/404');
         expect(jsonObj.statusCode).toBe(404);
         expect(jsonObj.result).toBeNull();
     });
 
     it('posts a json object', async() => {
         let res: any = { name: 'foo' };
-        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.postJson<HttpBinData>('https://httpbin.org/post', res);
+        let restRes: ifm.ITypedResponse<HttpBinData> = await _http.postJson<HttpBinData>('https://httpbin.org/post', res);
         expect(restRes.statusCode).toBe(200);
         expect(restRes.result).toBeDefined(); 
         expect(restRes.result.url).toBe('https://httpbin.org/post');
@@ -224,7 +225,7 @@ describe('basics', () => {
 
     it('puts a json object', async() => {
         let res: any = { name: 'foo' };
-        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.putJson<HttpBinData>('https://httpbin.org/put', res);
+        let restRes: ifm.ITypedResponse<HttpBinData> = await _http.putJson<HttpBinData>('https://httpbin.org/put', res);
         expect(restRes.statusCode).toBe(200);
         expect(restRes.result).toBeDefined(); 
         expect(restRes.result.url).toBe('https://httpbin.org/put');
@@ -233,7 +234,7 @@ describe('basics', () => {
     
     it('patch a json object', async() => {
         let res: any = { name: 'foo' };
-        let restRes: httpm.ITypedResponse<HttpBinData> = await _http.patchJson<HttpBinData>('https://httpbin.org/patch', res);
+        let restRes: ifm.ITypedResponse<HttpBinData> = await _http.patchJson<HttpBinData>('https://httpbin.org/patch', res);
         expect(restRes.statusCode).toBe(200);
         expect(restRes.result).toBeDefined(); 
         expect(restRes.result.url).toBe('https://httpbin.org/patch');

--- a/index.ts
+++ b/index.ts
@@ -71,12 +71,6 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
     }
 }
 
-export interface ITypedResponse<T> {
-    statusCode: number,
-    result: T | null,
-    headers: Object
-}
-
 export function isHttps(requestUrl: string) {
     let parsedUrl: url.Url = url.parse(requestUrl);
     return parsedUrl.protocol === 'https:';
@@ -172,24 +166,24 @@ export class HttpClient {
      * Gets a typed object from an endpoint
      * Be aware that not found returns a null.  Other errors (4xx, 5xx) reject the promise
      */
-    public async getJson<T>(requestUrl: string, additionalHeaders?: ifm.IHeaders): Promise<ITypedResponse<T>> {
+    public async getJson<T>(requestUrl: string, additionalHeaders?: ifm.IHeaders): Promise<ifm.ITypedResponse<T>> {
         let res: ifm.IHttpClientResponse = await this.get(requestUrl, additionalHeaders);
         return this._processResponse<T>(res, this.requestOptions);
     }
     
-    public async postJson<T>(requestUrl: string, obj:T, additionalHeaders?: ifm.IHeaders): Promise<ITypedResponse<T>> {
+    public async postJson<T>(requestUrl: string, obj: any, additionalHeaders?: ifm.IHeaders): Promise<ifm.ITypedResponse<T>> {
         let data: string = JSON.stringify(obj, null, 2);
         let res: ifm.IHttpClientResponse = await this.post(requestUrl, data, additionalHeaders);
         return this._processResponse<T>(res, this.requestOptions);
     }
 
-    public async putJson<T>(requestUrl: string, obj:T, additionalHeaders?: ifm.IHeaders): Promise<ITypedResponse<T>> {
+    public async putJson<T>(requestUrl: string, obj: any, additionalHeaders?: ifm.IHeaders): Promise<ifm.ITypedResponse<T>> {
         let data: string = JSON.stringify(obj, null, 2);
         let res: ifm.IHttpClientResponse = await this.put(requestUrl, data, additionalHeaders);
         return this._processResponse<T>(res, this.requestOptions);
     }    
 
-    public async patchJson<T>(requestUrl: string, obj:T, additionalHeaders?: ifm.IHeaders): Promise<ITypedResponse<T>> {
+    public async patchJson<T>(requestUrl: string, obj: any, additionalHeaders?: ifm.IHeaders): Promise<ifm.ITypedResponse<T>> {
         let data: string = JSON.stringify(obj, null, 2);
         let res: ifm.IHttpClientResponse = await this.patch(requestUrl, data, additionalHeaders);
         return this._processResponse<T>(res, this.requestOptions);
@@ -513,11 +507,11 @@ export class HttpClient {
         return value;
     }
 
-    private async _processResponse<T>(res: ifm.IHttpClientResponse, options: ifm.IRequestOptions): Promise<ITypedResponse<T>> {
-        return new Promise<ITypedResponse<T>>(async (resolve, reject) => {
+    private async _processResponse<T>(res: ifm.IHttpClientResponse, options: ifm.IRequestOptions): Promise<ifm.ITypedResponse<T>> {
+        return new Promise<ifm.ITypedResponse<T>>(async (resolve, reject) => {
             const statusCode: number = res.message.statusCode;
 
-            const response: ITypedResponse<T> = {
+            const response: ifm.ITypedResponse<T> = {
                 statusCode: statusCode,
                 result: null,
                 headers: {}

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -47,3 +47,9 @@ export interface IRequestOptions {
     allowRetries?: boolean;
     maxRetries?: number;
 }
+
+export interface ITypedResponse<T> {
+    statusCode: number,
+    result: T | null,
+    headers: Object
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
From comments on https://github.com/actions/http-client/pull/9

Allows `any` for json apis so that you can have different response and request types 

Moved an interface around 