### PR TITLE
Add support for gzip encoded responses

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -253,4 +253,13 @@ describe('basics', () => {
         expect(restRes.result.headers["Content-Type"]).toBe(httpm.MediaTypes.ApplicationJson);
         expect(restRes.headers[httpm.Headers.ContentType]).toBe(httpm.MediaTypes.ApplicationJson);
     });
+
+    it('does basic http get request with gzip encoded response', async() => {
+        const httpResponse: httpm.HttpClientResponse = await _http.get('http://httpbin.org/gzip');
+        const body: string = await httpResponse.readBody();
+        const bodyAsJSON:any = JSON.parse(body);
+
+        expect(bodyAsJSON.headers && bodyAsJSON.headers.Host).toBe("httpbin.org")
+        expect(httpResponse.message.statusCode).toBe(200)
+    });
 });

--- a/util.ts
+++ b/util.ts
@@ -9,8 +9,8 @@ import {IHttpClientResponse} from './interfaces'
  * @param {string} charset
  * @return {Promise<string>}
  */
-export async function decompressGzippedContent(buffer: Buffer, charset: string): Promise<string> {
-    return new Promise<string>(async (resolve, reject) => {
+export function decompressGzippedContent(buffer: Buffer, charset: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
         zlib.gunzip(buffer, function (error, buffer) {
             if (error) {
                 reject(error);

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,44 @@
+import zlib = require('zlib');
+import {IHttpClientResponse} from './interfaces'
+
+/**
+ * Decompress/Decode gzip encoded JSON
+ * Using Node.js built-in zlib module
+ *
+ * @param {Buffer} buffer
+ * @param {string} charset
+ * @return {Promise<string>}
+ */
+export async function decompressGzippedContent(buffer: Buffer, charset: string): Promise<string> {
+    return new Promise<string>(async (resolve, reject) => {
+        zlib.gunzip(buffer, function (error, buffer) {
+            if (error) {
+                reject(error);
+            }
+
+            resolve(buffer.toString(charset));
+        });
+    })
+}
+
+/**
+ * Obtain Response's Content Charset.
+ * Through inspecting `content-type` response header.
+ * It Returns 'utf-8' if NO charset specified/matched.
+ *
+ * @param {IHttpClientResponse} response
+ * @return {string} - Content Encoding Charset; Default=utf-8
+ */
+export function obtainContentCharset (response: IHttpClientResponse) : string {
+  // Find the charset, if specified.
+  // Search for the `charset=CHARSET` string, not including `;,\r\n`
+  // Example: content-type: 'application/json;charset=utf-8'
+  // |__ matches would be ['charset=utf-8', 'utf-8', index: 18, input: 'application/json; charset=utf-8']
+  // |_____ matches[1] would have the charset :tada: , in our example it's utf-8
+  // However, if the matches Array was empty or no charset found, 'utf-8' would be returned by default.
+
+  const contentType: string = response.message.headers['content-type'] || '';
+  const matches: (RegExpMatchArray|null) = contentType.match(/charset=([^;,\r\n]+)/i);
+
+  return (matches && matches[1]) ? matches[1] : 'utf-8';
+}


### PR DESCRIPTION
## Overview

Largely porting over some changes from the `microsoft/type-rest-client` that by default supports handling encoded responses: https://github.com/microsoft/typed-rest-client/pull/189

This is needed for the `v2` version of `download-aritfact` that is currently in preview and has some problems that are related to gzip. https://github.com/actions/download-artifact/issues/23

When currently calling `readBody()` the response body gets converted to a string with the default javascript encoding which is `utf-16`. When trying to ungzip this string, it is no longer possible to do because some information gets lost during the initial string conversion in this package. I've tried a host of different things including piping the resulting string to a file and attempting to ungzip it, but there is always this `incorrect header check` which indicates the data is in an incorrect format:

![image](https://user-images.githubusercontent.com/16109154/78136385-c837d100-7423-11ea-9603-95cce9803835.png)

The really simple program that I've been using for testing.

![image](https://user-images.githubusercontent.com/16109154/78136912-ab4fcd80-7424-11ea-92d2-8ecb6627168f.png)

I've also tried a host of different things using the node `Buffer` class to go between encodings, but it seems like there is some permanent information lost that cannot be retried after `readBody()` gets called: https://nodejs.org/docs/latest/api/buffer.html#buffer_buffers_and_character_encodings. I'm able to ungzip the body using the raw fiddler response when an artifact download is happening, so the issue is definitely in this package.

## Testing

Added a test to make sure the content correctly gets decoded

Successful end-to-end artifact download/upload with the changes: https://github.com/konradpabjan/artifact-test/runs/551807430?check_suite_focus=true

Downloading the artifacts from the UI shows the expected size, and inspecting the files reveals no gzip content which is expected.

After running `npm build` with these changes, i copied over the output to the `node_modules` directory in the forked `@actions/download-artifact` and `@actions/upload-artifact` directory that I've been testing with.




