### PR TITLE
Remove deprecated URL API usage

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -2,7 +2,6 @@ import * as http from 'http'
 import * as httpm from '../_out'
 import * as pm from '../_out/proxy'
 import * as proxy from 'proxy'
-import * as url from 'url'
 
 let _proxyConnects: string[]
 let _proxyServer: http.Server
@@ -39,107 +38,107 @@ describe('proxy', () => {
   })
 
   it('getProxyUrl does not return proxyUrl if variables not set', () => {
-    let proxyUrl = pm.getProxyUrl(url.parse('https://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('https://github.com'))
     expect(proxyUrl).toBeUndefined()
   })
 
   it('getProxyUrl returns proxyUrl if https_proxy set for https url', () => {
     process.env['https_proxy'] = 'https://myproxysvr'
-    let proxyUrl = pm.getProxyUrl(url.parse('https://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('https://github.com'))
     expect(proxyUrl).toBeDefined()
   })
 
   it('getProxyUrl does not return proxyUrl if http_proxy set for https url', () => {
     process.env['http_proxy'] = 'https://myproxysvr'
-    let proxyUrl = pm.getProxyUrl(url.parse('https://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('https://github.com'))
     expect(proxyUrl).toBeUndefined()
   })
 
   it('getProxyUrl returns proxyUrl if http_proxy set for http url', () => {
     process.env['http_proxy'] = 'http://myproxysvr'
-    let proxyUrl = pm.getProxyUrl(url.parse('http://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('http://github.com'))
     expect(proxyUrl).toBeDefined()
   })
 
   it('getProxyUrl does not return proxyUrl if https_proxy set and in no_proxy list', () => {
     process.env['https_proxy'] = 'https://myproxysvr'
     process.env['no_proxy'] = 'otherserver,myserver,anotherserver:8080'
-    let proxyUrl = pm.getProxyUrl(url.parse('https://myserver'))
+    let proxyUrl = pm.getProxyUrl(new URL('https://myserver'))
     expect(proxyUrl).toBeUndefined()
   })
 
   it('getProxyUrl returns proxyUrl if https_proxy set and not in no_proxy list', () => {
     process.env['https_proxy'] = 'https://myproxysvr'
     process.env['no_proxy'] = 'otherserver,myserver,anotherserver:8080'
-    let proxyUrl = pm.getProxyUrl(url.parse('https://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('https://github.com'))
     expect(proxyUrl).toBeDefined()
   })
 
   it('getProxyUrl does not return proxyUrl if http_proxy set and in no_proxy list', () => {
     process.env['http_proxy'] = 'http://myproxysvr'
     process.env['no_proxy'] = 'otherserver,myserver,anotherserver:8080'
-    let proxyUrl = pm.getProxyUrl(url.parse('http://myserver'))
+    let proxyUrl = pm.getProxyUrl(new URL('http://myserver'))
     expect(proxyUrl).toBeUndefined()
   })
 
   it('getProxyUrl returns proxyUrl if http_proxy set and not in no_proxy list', () => {
     process.env['http_proxy'] = 'http://myproxysvr'
     process.env['no_proxy'] = 'otherserver,myserver,anotherserver:8080'
-    let proxyUrl = pm.getProxyUrl(url.parse('http://github.com'))
+    let proxyUrl = pm.getProxyUrl(new URL('http://github.com'))
     expect(proxyUrl).toBeDefined()
   })
 
   it('checkBypass returns true if host as no_proxy list', () => {
     process.env['no_proxy'] = 'myserver'
-    let bypass = pm.checkBypass(url.parse('https://myserver'))
+    let bypass = pm.checkBypass(new URL('https://myserver'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host in no_proxy list', () => {
     process.env['no_proxy'] = 'otherserver,myserver,anotherserver:8080'
-    let bypass = pm.checkBypass(url.parse('https://myserver'))
+    let bypass = pm.checkBypass(new URL('https://myserver'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host in no_proxy list with spaces', () => {
     process.env['no_proxy'] = 'otherserver, myserver ,anotherserver:8080'
-    let bypass = pm.checkBypass(url.parse('https://myserver'))
+    let bypass = pm.checkBypass(new URL('https://myserver'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host in no_proxy list with port', () => {
     process.env['no_proxy'] = 'otherserver, myserver:8080 ,anotherserver'
-    let bypass = pm.checkBypass(url.parse('https://myserver:8080'))
+    let bypass = pm.checkBypass(new URL('https://myserver:8080'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host with port in no_proxy list without port', () => {
     process.env['no_proxy'] = 'otherserver, myserver ,anotherserver'
-    let bypass = pm.checkBypass(url.parse('https://myserver:8080'))
+    let bypass = pm.checkBypass(new URL('https://myserver:8080'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host in no_proxy list with default https port', () => {
     process.env['no_proxy'] = 'otherserver, myserver:443 ,anotherserver'
-    let bypass = pm.checkBypass(url.parse('https://myserver'))
+    let bypass = pm.checkBypass(new URL('https://myserver'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns true if host in no_proxy list with default http port', () => {
     process.env['no_proxy'] = 'otherserver, myserver:80 ,anotherserver'
-    let bypass = pm.checkBypass(url.parse('http://myserver'))
+    let bypass = pm.checkBypass(new URL('http://myserver'))
     expect(bypass).toBeTruthy()
   })
 
   it('checkBypass returns false if host not in no_proxy list', () => {
     process.env['no_proxy'] = 'otherserver, myserver ,anotherserver:8080'
-    let bypass = pm.checkBypass(url.parse('https://github.com'))
+    let bypass = pm.checkBypass(new URL('https://github.com'))
     expect(bypass).toBeFalsy()
   })
 
   it('checkBypass returns false if empty no_proxy', () => {
     process.env['no_proxy'] = ''
-    let bypass = pm.checkBypass(url.parse('https://github.com'))
+    let bypass = pm.checkBypass(new URL('https://github.com'))
     expect(bypass).toBeFalsy()
   })
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import url = require('url')
 import http = require('http')
 import https = require('https')
 import ifm = require('./interfaces')
@@ -50,7 +49,7 @@ export enum MediaTypes {
  * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
  */
 export function getProxyUrl(serverUrl: string): string {
-  let proxyUrl = pm.getProxyUrl(url.parse(serverUrl))
+  let proxyUrl = pm.getProxyUrl(new URL(serverUrl))
   return proxyUrl ? proxyUrl.href : ''
 }
 
@@ -92,7 +91,7 @@ export class HttpClientResponse implements ifm.IHttpClientResponse {
 }
 
 export function isHttps(requestUrl: string) {
-  let parsedUrl: url.Url = url.parse(requestUrl)
+  let parsedUrl: URL = new URL(requestUrl)
   return parsedUrl.protocol === 'https:'
 }
 
@@ -322,7 +321,7 @@ export class HttpClient {
       throw new Error('Client has already been disposed.')
     }
 
-    let parsedUrl = url.parse(requestUrl)
+    let parsedUrl = new URL(requestUrl)
     let info: ifm.IRequestInfo = this._prepareRequest(verb, parsedUrl, headers)
 
     // Only perform retries on reads since writes may not be idempotent.
@@ -371,7 +370,7 @@ export class HttpClient {
           // if there's no location to redirect to, we won't
           break
         }
-        let parsedRedirectUrl = url.parse(redirectUrl)
+        let parsedRedirectUrl = new URL(redirectUrl)
         if (
           parsedUrl.protocol == 'https:' &&
           parsedUrl.protocol != parsedRedirectUrl.protocol &&
@@ -516,13 +515,13 @@ export class HttpClient {
    * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
    */
   public getAgent(serverUrl: string): http.Agent {
-    let parsedUrl = url.parse(serverUrl)
+    let parsedUrl = new URL(serverUrl)
     return this._getAgent(parsedUrl)
   }
 
   private _prepareRequest(
     method: string,
-    requestUrl: url.Url,
+    requestUrl: URL,
     headers: ifm.IHeaders
   ): ifm.IRequestInfo {
     const info: ifm.IRequestInfo = <ifm.IRequestInfo>{}
@@ -587,9 +586,9 @@ export class HttpClient {
     return additionalHeaders[header] || clientHeader || _default
   }
 
-  private _getAgent(parsedUrl: url.Url): http.Agent {
+  private _getAgent(parsedUrl: URL): http.Agent {
     let agent
-    let proxyUrl: url.Url = pm.getProxyUrl(parsedUrl)
+    let proxyUrl: URL = pm.getProxyUrl(parsedUrl)
     let useProxy = proxyUrl && proxyUrl.hostname
 
     if (this._keepAlive && useProxy) {
@@ -621,7 +620,7 @@ export class HttpClient {
         maxSockets: maxSockets,
         keepAlive: this._keepAlive,
         proxy: {
-          proxyAuth: proxyUrl.auth,
+          proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`,
           host: proxyUrl.hostname,
           port: proxyUrl.port
         }

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -1,5 +1,4 @@
 import http = require('http')
-import url = require('url')
 
 export interface IHeaders {
   [key: string]: any
@@ -73,7 +72,7 @@ export interface IHttpClientResponse {
 
 export interface IRequestInfo {
   options: http.RequestOptions
-  parsedUrl: url.Url
+  parsedUrl: URL
   httpModule: any
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,9 +1,7 @@
-import * as url from 'url'
-
-export function getProxyUrl(reqUrl: url.Url): url.Url | undefined {
+export function getProxyUrl(reqUrl: URL): URL | undefined {
   let usingSsl = reqUrl.protocol === 'https:'
 
-  let proxyUrl: url.Url
+  let proxyUrl: URL
   if (checkBypass(reqUrl)) {
     return proxyUrl
   }
@@ -16,13 +14,13 @@ export function getProxyUrl(reqUrl: url.Url): url.Url | undefined {
   }
 
   if (proxyVar) {
-    proxyUrl = url.parse(proxyVar)
+    proxyUrl = new URL(proxyVar)
   }
 
   return proxyUrl
 }
 
-export function checkBypass(reqUrl: url.Url): boolean {
+export function checkBypass(reqUrl: URL): boolean {
   if (!reqUrl.hostname) {
     return false
   }


### PR DESCRIPTION
The legacy URL API (provided by `require('url')`) was deprecated by NodeJS 11 released in October 2018. It is scheduled to be removed in a future release.

The main motivation for this change, is Yarn v2, which does not allow undeclared dependencies to be used. `require('url')` is ambiguous between the built-in NodeJS module, and the npm package [url](https://www.npmjs.com/package/url). I'm assuming the intent is to use the built-in module, so I've migrated to using the new URL API, for which the import is implicit.