### PR TITLE
Redirects should not pass authorization to different domain

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -181,47 +181,47 @@ describe('basics', () => {
 
   it('does not pass auth with diff hostname redirects', async done => {
     let headers = {
-      "accept": "application/json",
-      "authorization": "shhh"
+      accept: 'application/json',
+      authorization: 'shhh'
     }
     let res: httpm.HttpClientResponse = await _http.get(
       'https://httpbin.org/redirect-to?url=' +
         encodeURIComponent('https://www.httpbin.org/get'),
-        headers
+      headers
     )
 
     expect(res.message.statusCode).toBe(200)
     let body: string = await res.readBody()
     let obj: any = JSON.parse(body)
     // httpbin "fixes" the casing
-    expect(obj.headers["Authorization"]).toBeUndefined()
-    expect(obj.headers["authorization"]).toBeUndefined()
+    expect(obj.headers['Authorization']).toBeUndefined()
+    expect(obj.headers['authorization']).toBeUndefined()
     expect(obj.url).toBe('https://www.httpbin.org/get')
 
     done()
   })
-  
+
   it('does not pass Auth with diff hostname redirects', async done => {
     let headers = {
-      "Accept": "application/json",
-      "Authorization": "shhh"
+      Accept: 'application/json',
+      Authorization: 'shhh'
     }
     let res: httpm.HttpClientResponse = await _http.get(
       'https://httpbin.org/redirect-to?url=' +
         encodeURIComponent('https://www.httpbin.org/get'),
-        headers
+      headers
     )
 
     expect(res.message.statusCode).toBe(200)
     let body: string = await res.readBody()
     let obj: any = JSON.parse(body)
     // httpbin "fixes" the casing
-    expect(obj.headers["Authorization"]).toBeUndefined()
-    expect(obj.headers["authorization"]).toBeUndefined()
+    expect(obj.headers['Authorization']).toBeUndefined()
+    expect(obj.headers['authorization']).toBeUndefined()
     expect(obj.url).toBe('https://www.httpbin.org/get')
 
     done()
-  })  
+  })
 
   it('does basic head request', async done => {
     let res: httpm.HttpClientResponse = await _http.head(

--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -179,6 +179,50 @@ describe('basics', () => {
     done()
   })
 
+  it('does not pass auth with diff hostname redirects', async done => {
+    let headers = {
+      "accept": "application/json",
+      "authorization": "shhh"
+    }
+    let res: httpm.HttpClientResponse = await _http.get(
+      'https://httpbin.org/redirect-to?url=' +
+        encodeURIComponent('https://www.httpbin.org/get'),
+        headers
+    )
+
+    expect(res.message.statusCode).toBe(200)
+    let body: string = await res.readBody()
+    let obj: any = JSON.parse(body)
+    // httpbin "fixes" the casing
+    expect(obj.headers["Authorization"]).toBeUndefined()
+    expect(obj.headers["authorization"]).toBeUndefined()
+    expect(obj.url).toBe('https://www.httpbin.org/get')
+
+    done()
+  })
+  
+  it('does not pass Auth with diff hostname redirects', async done => {
+    let headers = {
+      "Accept": "application/json",
+      "Authorization": "shhh"
+    }
+    let res: httpm.HttpClientResponse = await _http.get(
+      'https://httpbin.org/redirect-to?url=' +
+        encodeURIComponent('https://www.httpbin.org/get'),
+        headers
+    )
+
+    expect(res.message.statusCode).toBe(200)
+    let body: string = await res.readBody()
+    let obj: any = JSON.parse(body)
+    // httpbin "fixes" the casing
+    expect(obj.headers["Authorization"]).toBeUndefined()
+    expect(obj.headers["authorization"]).toBeUndefined()
+    expect(obj.url).toBe('https://www.httpbin.org/get')
+
+    done()
+  })  
+
   it('does basic head request', async done => {
     let res: httpm.HttpClientResponse = await _http.head(
       'http://httpbin.org/get'

--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -194,6 +194,7 @@ describe('basics', () => {
     let body: string = await res.readBody()
     let obj: any = JSON.parse(body)
     // httpbin "fixes" the casing
+    expect(obj.headers['Accept']).toBe('application/json')
     expect(obj.headers['Authorization']).toBeUndefined()
     expect(obj.headers['authorization']).toBeUndefined()
     expect(obj.url).toBe('https://www.httpbin.org/get')
@@ -216,6 +217,7 @@ describe('basics', () => {
     let body: string = await res.readBody()
     let obj: any = JSON.parse(body)
     // httpbin "fixes" the casing
+    expect(obj.headers['Accept']).toBe('application/json')
     expect(obj.headers['Authorization']).toBeUndefined()
     expect(obj.headers['authorization']).toBeUndefined()
     expect(obj.url).toBe('https://www.httpbin.org/get')

--- a/index.ts
+++ b/index.ts
@@ -388,10 +388,10 @@ export class HttpClient {
 
         // strip authorization header if redirected to a different hostname
         if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
-          for(let header in headers){
+          for (let header in headers) {
             // header names are case insensitive
-            if (header.toLowerCase() === "authorization") {
-              delete headers[header] 
+            if (header.toLowerCase() === 'authorization') {
+              delete headers[header]
             }
           }
         }

--- a/index.ts
+++ b/index.ts
@@ -386,6 +386,16 @@ export class HttpClient {
         // which will leak the open socket.
         await response.readBody()
 
+        // strip authorization header if redirected to a different hostname
+        if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+          for(let header in headers){
+            // header names are case insensitive
+            if (header.toLowerCase() === "authorization") {
+              delete headers[header] 
+            }
+          }
+        }
+
         // let's make the request with the new redirectUrl
         info = this._prepareRequest(verb, parsedRedirectUrl, headers)
         response = await this.requestRaw(info, data)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Actions Http Client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a request is redirected to a different domain, the authorization header should be stripped.