### PR TITLE
Throw HttpClientError instead of Error

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 ## Releases
 
+## 1.0.9
+Throw HttpClientError instead of a generic Error from the \<verb>Json() helper methods when the server responds with a non-successful status code. 
+
 ## 1.0.7
 Update NPM dependencies and add 429 to the list of HttpCodes
 

--- a/index.ts
+++ b/index.ts
@@ -70,6 +70,18 @@ const RetryableHttpVerbs: string[] = ['OPTIONS', 'GET', 'DELETE', 'HEAD']
 const ExponentialBackoffCeiling = 10
 const ExponentialBackoffTimeSlice = 5
 
+export class HttpClientError extends Error {
+  constructor(message: string, statusCode: number) {
+    super(message)
+    this.name = 'HttpClientError'
+    this.statusCode = statusCode
+    Object.setPrototypeOf(this, HttpClientError.prototype)
+  }
+
+  public statusCode: number
+  public result?: any
+}
+
 export class HttpClientResponse implements ifm.IHttpClientResponse {
   constructor(message: http.IncomingMessage) {
     this.message = message
@@ -733,13 +745,8 @@ export class HttpClient {
           msg = 'Failed request: (' + statusCode + ')'
         }
 
-        let err: Error = new Error(msg)
-
-        // attach statusCode and body obj (if available) to the error object
-        err['statusCode'] = statusCode
-        if (response.result) {
-          err['result'] = response.result
-        }
+        let err = new HttpClientError(msg, statusCode)
+        err.result = response.result
 
         reject(err)
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actions/http-client",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "Actions Http Client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `<verb>Json` helper methods throw an Error when the server responds with a non-zero status code.  They also attach the status code and result as properties.

```
err['statusCode'] = ...
err['result'] = ...
```

This, however, is not compatible with TypeScript strict type checking.  As a result, code depending on `http-client` that use strict type checking (such as `actions/toolkit`) can't read the status code and result properties without resorting to TypeScript hacks, such as casting the error object to `any` and ignoring the resulting lint warnings.

This PR adds a new error subclass, `HttpClientError`, which properties to store the status code and result.  Throwing a different error type also lets callers distinguish between errors related to the API call from other generic errors, such as socket errors.