### PR TITLE
Disable redirect tests due to httpbin issue

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -128,7 +128,7 @@ describe('basics', () => {
     })
   })
 
-  it('does basic get request with redirects', async done => {
+  it.skip('does basic get request with redirects', async done => {
     let res: httpm.HttpClientResponse = await _http.get(
       'https://httpbin.org/redirect-to?url=' +
         encodeURIComponent('https://httpbin.org/get')
@@ -140,7 +140,7 @@ describe('basics', () => {
     done()
   })
 
-  it('does basic get request with redirects (303)', async done => {
+  it.skip('does basic get request with redirects (303)', async done => {
     let res: httpm.HttpClientResponse = await _http.get(
       'https://httpbin.org/redirect-to?url=' +
         encodeURIComponent('https://httpbin.org/get') +
@@ -164,7 +164,7 @@ describe('basics', () => {
     done()
   })
 
-  it('does not follow redirects if disabled', async done => {
+  it.skip('does not follow redirects if disabled', async done => {
     let http: httpm.HttpClient = new httpm.HttpClient(
       'typed-test-client-tests',
       null,
@@ -179,7 +179,7 @@ describe('basics', () => {
     done()
   })
 
-  it('does not pass auth with diff hostname redirects', async done => {
+  it.skip('does not pass auth with diff hostname redirects', async done => {
     let headers = {
       accept: 'application/json',
       authorization: 'shhh'
@@ -202,7 +202,7 @@ describe('basics', () => {
     done()
   })
 
-  it('does not pass Auth with diff hostname redirects', async done => {
+  it.skip('does not pass Auth with diff hostname redirects', async done => {
     let headers = {
       Accept: 'application/json',
       Authorization: 'shhh'


### PR DESCRIPTION
Disable redirect tests due to httpbin issue https://github.com/postmanlabs/httpbin/issues/617.

Created https://github.com/actions/http-client/issues/34 to track re-enabling these tests at some later point.