### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,15 @@
 name: http-tests
-on: 
+on:
   push:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   build:
     name: Build
 
@@ -23,29 +22,30 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup node
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Compile
-      run: npm run build
+      - name: Compile
+        run: npm run build
 
-    - name: npm test
-      run: npm test
+      - name: npm test
+        run: npm test
 
-    - name: Format
-      shell: bash
-      run: npm run format-check
-      if: matrix.runs-on == 'ubuntu-latest'
+      - name: Format
+        shell: bash
+        run: npm run format-check
+        if: matrix.runs-on == 'ubuntu-latest'
 
-    - name: audit security
-      continue-on-error: true
-      run: npm audit --audit-level=moderate
-      if: matrix.runs-on == 'ubuntu-latest'
+      - name: audit security
+        continue-on-error: true
+        run: npm audit --audit-level=moderate
+        if: matrix.runs-on == 'ubuntu-latest'


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
