### PR TITLE
chore(ci) : setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: monthly


### PR DESCRIPTION
sets up Dependabot for a monthly check on github-actions and npm dependencies