### PR TITLE
Allow overriding `user-agent` via `headers`.

### DIFF
--- a/__tests__/basics.test.ts
+++ b/__tests__/basics.test.ts
@@ -62,6 +62,21 @@ describe('basics', () => {
     done()
   })
 
+  it('does basic http get request with overridden user agent', async done => {
+    let res: httpm.HttpClientResponse = await _http.get(
+      'http://httpbin.org/get',
+      {
+        'user-agent': 'custom-user-agent'
+      }
+    )
+    expect(res.message.statusCode).toBe(200)
+    let body: string = await res.readBody()
+    let obj: any = JSON.parse(body)
+    expect(obj.url).toBe('http://httpbin.org/get')
+    expect(obj.headers['User-Agent']).toBe('custom-user-agent')
+    done()
+  })
+
   it('does basic https get request', async done => {
     let res: httpm.HttpClientResponse = await _http.get(
       'https://httpbin.org/get'

--- a/index.ts
+++ b/index.ts
@@ -562,7 +562,7 @@ export class HttpClient {
       (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '')
     info.options.method = method
     info.options.headers = this._mergeHeaders(headers)
-    if (this.userAgent != null) {
+    if (this.userAgent != null && !('user-agent' in info.options.headers)) {
       info.options.headers['user-agent'] = this.userAgent
     }
 


### PR DESCRIPTION
This PR adds the ability to override the `user-agent` via the `headers` option. This is useful, for example, when the `user-agent` is set to some value in a dependency (e.g., [here](https://github.com/actions/toolkit/blob/2f164000dcd42fb08287824a3bc3030dbed33687/packages/tool-cache/src/tool-cache.ts#L89)), also allowing users to control the `user-agent` per request (not just per `HttpClient`).